### PR TITLE
[IT-598] includ cloudformation stack name in email

### DIFF
--- a/ec2_notify.py
+++ b/ec2_notify.py
@@ -48,6 +48,7 @@ class EC2Notify(Hook):
 
         # EC2 info is auto assigned and only available in CF outputs
         ec2_info ={}
+        ec2_info['stack_name'] = self.stack.name
         ec2_info['id'] = utils.get_output_value(
             stack_outputs,
             self.stack.region + '-' + self.stack.external_name + '-' + 'Ec2InstanceId')
@@ -74,20 +75,20 @@ class EC2Notify(Hook):
 
         if 'public_ip' in ec2_info:
             message = message + ("<b> Resource Connection Info </b> <br />"
-                                 "If you provisioned an EC2 linux instance: <br />"
+                                 "If you requested an EC2 linux instance: <br />"
                                  "Open a terminal, then type ssh YOUR_JUMPCLOUD_USERNAME@IP_ADDRESS "
                                  "(i.e. ssh jsmith@" + ec2_info["public_ip"] + ") <br />"
-                                 "If you provisioned a Windows EC2: <br />"
+                                 "If you provisioned a Windows instance: <br />"
                                  "Run a "
                                  "<a href=\"https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/remote-desktop-clients\">RDP client</a> "
                                  "then connect to " + ec2_info["public_ip"] + " with your Jumpcloud credentials")
         else:
             message = message + ("<b> Resource Connection Info </b> <br />"
                                  "Login to the Sage VPN <br />"
-                                 "If you provisioned an EC2 linux instance: <br />"
+                                 "If you requested an EC2 linux instance: <br />"
                                  "Open a terminal, then type ssh YOUR_JUMPCLOUD_USERNAME@IP_ADDRESS "
                                  "(i.e. ssh jsmith@" + ec2_info["private_ip"] + ") <br />"
-                                 "If you provisioned a Windows EC2: <br />"
+                                 "If you requested a Windows instance: <br />"
                                  "Run a "
                                  "<a href=\"https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/remote-desktop-clients\">RDP client</a> "
                                  "then connect to " + ec2_info["private_ip"] + " with your Jumpcloud credentials")

--- a/s3_notify.py
+++ b/s3_notify.py
@@ -69,8 +69,9 @@ class S3Notify(Hook):
             self.create_owner_file(synapse_username, s3_bucket)
 
         # Send notification to resource owner
-        message =  ("A S3 bucket has been provisioned on your behalf. "
-                    "The bucket's name is " + s3_bucket)
+        message =  ("A S3 bucket has been provisioned on your behalf.\n"
+                    " Cloudformation stack: " + self.stack.name + "\n"
+                    " Bucket name: " + s3_bucket + "\n")
         try:
             response = utils.email_owner(
                 self.stack,

--- a/s3_web_notify.py
+++ b/s3_web_notify.py
@@ -52,12 +52,13 @@ class S3WebNotify(Hook):
         cloudfront_endpoint = utils.get_output_value(
             stack_outputs,
             self.stack.region + '-' + self.stack.external_name + '-' + 'CloudfrontEndpoint')
-        self.logger.info("Cloudfront endpoint: " +  cloudfront_endpoint)
+        self.logger.info("Cloudfront endpoint: " + cloudfront_endpoint)
 
-        message =  ("A cloudfront website has been provisioned on your behalf."
-                    " The contents of the website is in an S3 bucket. "
-                    " The bucket name is " + website_bucket +
-                    " The cloudfront endpoint is " + cloudfront_endpoint)
+        message =  ("A cloudfront website has been provisioned on your behalf. "
+                    "The contents of the website is in an S3 bucket.\n"
+                    " Cloudformation stack: " + self.stack.name + "\n"
+                    " Bucket name: " + website_bucket + "\n"
+                    " Cloudfront endpoint: " + cloudfront_endpoint + "\n")
         try:
             response = utils.email_owner(
                 self.stack,


### PR DESCRIPTION
Adding stack name to the provisioner notification allows users
to correlate the stack that created the requested resource.
This ultimately makes it easy to track back to the PR for the
requested resource.